### PR TITLE
Replace task references with card nomenclature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Edit `config.json` with the following fields:
 - `since`/`until`: date range (format YYYY-MM-DD)
 - `outputDir`: folder where result files will be written
 - `allowDuplicates`: when `false`, only the most recent change of each file is listed
-- `task`: task number to associate with effort entries 5.32.x in the final report
+- `card`: card number to associate with effort entries 5.32.x in the final report
 
 A sample file is provided in `config.example.json`.
 The USTIBB task definitions are stored in `ustibb_map.json`. Edit this file if you need to adjust the codes or point values.
@@ -23,13 +23,13 @@ npm install
 npm start
 ```
 
-The script will search for repositories under `baseDir` and create one text file per project in `outputDir` listing modified files. Each line contains the file path, the abbreviated commit hash and, when present in the commit message, the task number. The number may contain any amount of digits:
+The script will search for repositories under `baseDir` and create one text file per project in `outputDir` listing modified files. Each line contains the file path, the abbreviated commit hash and, when present in the commit message, the card number. The number may contain any amount of digits:
 
 ```
-path/to/file.java#abcdef1234; task 1234567
+path/to/file.java#abcdef1234; card 1234567
 ```
 
 In the generated files the entries are grouped by USTIBB code. Each block shows the files and the score calculated from `ustibb_map.json`.
 
 The consolidated `final-commit-report.txt` also includes the activities 5.32.1,
-5.32.2 and 5.32.3 using the task number set in `config.json`.
+5.32.2 and 5.32.3 using the card number set in `config.json`.

--- a/config.json
+++ b/config.json
@@ -5,5 +5,5 @@
   "until": "2025-07-22",
   "outputDir": "./output",
   "allowDuplicates": false,
-  "task": ""
+  "card": ""
 }

--- a/index.js
+++ b/index.js
@@ -15,8 +15,12 @@ function loadConfig() {
   if (typeof cfg.allowDuplicates !== 'boolean') {
     cfg.allowDuplicates = true;
   }
-  if (typeof cfg.task !== 'string') {
-    cfg.task = '';
+  if (typeof cfg.card !== 'string') {
+    if (typeof cfg.task === 'string') {
+      cfg.card = cfg.task;
+    } else {
+      cfg.card = '';
+    }
   }
   return cfg;
 }
@@ -72,7 +76,7 @@ function processRepo(repoPath, config, ustibbMap) {
   return repoTotal;
 }
 
-function gerarRelatorioFinal(outputDir, task) {
+function gerarRelatorioFinal(outputDir, card) {
   const categories = {};
   const projects = fs.readdirSync(outputDir, { withFileTypes: true })
     .filter(d => d.isDirectory())
@@ -128,7 +132,9 @@ function gerarRelatorioFinal(outputDir, task) {
   extras.forEach((code, idx) => {
     if (!ustibb[code]) return;
     outLines.push(`${code} - ${ustibb[code].descricao}`);
-    outLines.push(`task ${task}`);
+    if (card) {
+      outLines.push(`card ${card}`);
+    }
     if (idx < extras.length - 1) {
       outLines.push('---');
     }
@@ -152,7 +158,7 @@ function run() {
     }
   }
   console.log(`Total geral de USTIBB: ${total}`);
-  gerarRelatorioFinal(config.outputDir, config.task);
+  gerarRelatorioFinal(config.outputDir, config.card);
 }
 
 run();

--- a/lib/gitUtils.js
+++ b/lib/gitUtils.js
@@ -35,9 +35,9 @@ function getCommits(repoPath, author, since, until) {
     .filter(Boolean)
     .map(line => {
       const [hash, subject = ''] = line.split('|');
-      // extract task numbers of any length
-      const match = subject.match(/task (\d+)/i);
-      return { hash, task: match ? match[1] : null };
+      // extract card numbers of any length
+      const match = subject.match(/card (\d+)/i) || subject.match(/task (\d+)/i);
+      return { hash, card: match ? match[1] : null };
     });
 }
 
@@ -67,7 +67,13 @@ function parseGitShow(output) {
 
 function formatLine(filePath, commit) {
   const base = `${filePath}#${commit.hash.substring(0, 10)};`;
-  return commit.task ? `${base} task ${commit.task}` : base;
+  if (commit.card) {
+    return `${base} card ${commit.card}`;
+  }
+  if (commit.task) {
+    return `${base} task ${commit.task}`;
+  }
+  return base;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- adjust configuration loading to prefer the new `card` field while keeping compatibility with legacy `task` values
- update commit parsing and line formatting to capture `card` identifiers from messages and output them in reports
- refresh documentation and sample configuration to reference cards instead of tasks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e67a5c3f10832bb7d00f5024ffb1b7