### PR TITLE
Handle GitHub author mapping and diagnostics

### DIFF
--- a/author_map.json
+++ b/author_map.json
@@ -1,0 +1,8 @@
+{
+  "C1321687": {
+    "aliases": ["C1321687_BBrasil"],
+    "logins": ["C1321687_BBrasil"],
+    "names": ["C1321687"],
+    "emails": []
+  }
+}

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const {
   formatLine
 } = require('./lib/gitUtils');
 const { loadMap, getCodeForFile } = require('./lib/ustibb');
+const { loadAuthorMap, resolveAuthorMatchers } = require('./lib/author');
 
 function loadConfig() {
   const configPath = path.join(__dirname, 'config.json');
@@ -29,13 +30,19 @@ function ensureDir(dir) {
   fs.mkdirSync(dir, { recursive: true });
 }
 
-function processRepo(repoPath, config, ustibbMap) {
+function processRepo(repoPath, config, ustibbMap, authorMatchers) {
   console.log(`Processing ${repoPath}`);
-  const commits = getCommits(repoPath, config.author, config.since, config.until);
+  const commits = getCommits(repoPath, authorMatchers, config.since, config.until);
+  console.log(`  commits found (after author/date filter): ${commits.length}`);
   const groups = {};
+  const globalSeen = new Set();
+  let totalFiles = 0;
+  let addedFiles = 0;
+  let skippedDuplicates = 0;
 
   for (const commit of commits) {
     const files = getFilesForCommit(repoPath, commit.hash);
+    totalFiles += files.length;
     for (const f of files) {
       const code = getCodeForFile(ustibbMap, f.path, f.status);
       if (!code) continue;
@@ -47,14 +54,21 @@ function processRepo(repoPath, config, ustibbMap) {
           seen: new Set()
         };
       }
-      if (!config.allowDuplicates && groups[code].seen.has(f.path)) {
+      const pathKey = f.path;
+      if (!config.allowDuplicates && (groups[code].seen.has(pathKey) || globalSeen.has(pathKey))) {
+        skippedDuplicates++;
         continue;
       }
-      groups[code].seen.add(f.path);
+      groups[code].seen.add(pathKey);
+      globalSeen.add(pathKey);
       const fullPath = path.join(path.basename(repoPath), f.path);
       groups[code].lines.push(formatLine(fullPath, commit));
+      addedFiles++;
     }
   }
+
+  console.log(`  files scanned: ${totalFiles}`);
+  console.log(`  files added: ${addedFiles}${config.allowDuplicates ? '' : ` (skipped duplicates: ${skippedDuplicates})`}`);
 
   const repoName = path.basename(repoPath);
   const outputDir = path.join(config.outputDir, repoName);
@@ -70,6 +84,9 @@ function processRepo(repoPath, config, ustibbMap) {
     output.push(...g.lines);
     output.push(`Total USTIBB: ${g.lines.length} x ${g.ustibb} = ${subtotal}`);
     output.push('');
+  }
+  if (!output.length) {
+    output.push(`Nenhum commit encontrado para ${config.author} entre ${config.since} e ${config.until}.`);
   }
   output.push(`Total geral do projeto: ${repoTotal}`);
   fs.writeFileSync(path.join(outputDir, 'commits.txt'), output.join('\n'), 'utf8');
@@ -146,13 +163,21 @@ function gerarRelatorioFinal(outputDir, card) {
 
 function run() {
   const config = loadConfig();
+  const authorMap = loadAuthorMap();
+  const authorMatchers = resolveAuthorMatchers(config.author, authorMap);
   const ustibbMap = loadMap();
   ensureDir(config.outputDir);
-  const repos = findGitRepos(path.resolve(config.baseDir));
+  const basePath = path.resolve(config.baseDir);
+  if (!fs.existsSync(basePath)) {
+    console.error(`Base directory does not exist: ${basePath}`);
+    return;
+  }
+  const repos = findGitRepos(basePath);
+  console.log(`Found ${repos.length} git repos under ${basePath}`);
   let total = 0;
   for (const repo of repos) {
     try {
-      total += processRepo(repo, config, ustibbMap);
+      total += processRepo(repo, config, ustibbMap, authorMatchers);
     } catch (err) {
       console.error(`Failed to process ${repo}:`, err.message);
     }

--- a/lib/author.js
+++ b/lib/author.js
@@ -1,0 +1,39 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function loadAuthorMap() {
+  const mapPath = path.join(__dirname, '..', 'author_map.json');
+  if (!fs.existsSync(mapPath)) {
+    return {};
+  }
+  try {
+    const raw = fs.readFileSync(mapPath, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    console.error(`Could not read author map: ${err.message}`);
+    return {};
+  }
+}
+
+function resolveAuthorMatchers(authorId, authorMap = {}) {
+  const entry = authorMap[authorId] || {};
+  const aliases = Array.isArray(entry.aliases) ? entry.aliases : [];
+  const names = Array.isArray(entry.names) ? entry.names : [];
+  const emails = Array.isArray(entry.emails) ? entry.emails : [];
+  const logins = Array.isArray(entry.logins) ? entry.logins : [];
+  const parts = [authorId, ...aliases, ...names, ...emails, ...logins]
+    .filter(Boolean)
+    .map(v => v.trim())
+    .filter(Boolean);
+  const unique = Array.from(new Set(parts));
+  if (!unique.length) {
+    console.warn(`No author matchers resolved for ${authorId}, using raw value.`);
+    return [authorId];
+  }
+  return unique;
+}
+
+module.exports = {
+  loadAuthorMap,
+  resolveAuthorMatchers
+};

--- a/lib/gitUtils.js
+++ b/lib/gitUtils.js
@@ -1,4 +1,4 @@
-const { execSync, execFileSync } = require('node:child_process');
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -20,16 +20,30 @@ function findGitRepos(dir, repos = []) {
   return repos;
 }
 
-function getCommits(repoPath, author, since, until) {
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getCommits(repoPath, authorMatchers, since, until) {
+  const authorArg = Array.isArray(authorMatchers)
+    ? `--author=${authorMatchers.map(escapeRegex).join('|')}`
+    : `--author=${escapeRegex(authorMatchers || '')}`;
   const args = [
     '-C', repoPath,
     'log',
-    `--author=${author}`,
+    authorArg,
     `--since=${since}`,
     `--until=${until}`,
     '--pretty=format:%H|%s'
   ];
-  const output = execFileSync('git', args, { encoding: 'utf8' });
+  let output = '';
+  try {
+    output = execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    const detail = err.stderr?.toString().trim() || err.message;
+    console.error(`    git log failed in ${repoPath}: ${detail}`);
+    return [];
+  }
   return output
     .split(/\r?\n/)
     .filter(Boolean)
@@ -50,7 +64,14 @@ function getFilesForCommit(repoPath, commitHash) {
     '-r',
     commitHash
   ];
-  const output = execFileSync('git', args, { encoding: 'utf8' });
+  let output = '';
+  try {
+    output = execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    const detail = err.stderr?.toString().trim() || err.message;
+    console.error(`    git diff-tree failed for ${commitHash} in ${repoPath}: ${detail}`);
+    return [];
+  }
   return parseGitShow(output);
 }
 


### PR DESCRIPTION
## Summary
- add an author matcher map so GitHub Enterprise logins resolve to configured IDs
- improve git command error handling, logging, and duplicate filtering
- write clearer output when no commits match the filters

## Testing
- node index.js *(fails: node runtime not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69325b7fb5ec832b8292748e2788a930)